### PR TITLE
Add PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "jms/serializer": "^3.1"
     },


### PR DESCRIPTION
PHP 7.4 is reaching EOL later this year. PHP 8 support requires no significant changes other than the statement for composer requires.

Solid project to be honest, you did a really good job! 💯👌
